### PR TITLE
fix: split '... part of Expression' property in two

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -828,9 +828,13 @@ def update_properties():
 
     delete_is_part_of_work = Property.objects.filter(name="is part of work").delete()
 
-    # rename name field of Expression/Expression relation
-    for prop in Property.objects.filter(name="is part of expression"):
-        prop.name = "is part of"
+    # rename "name" field of Expression/Expression relation
+    # and also rename "name_reverse" field
+    for prop in Property.objects.filter(
+        name__in=["is part of expression", "is part of"]
+    ):
+        prop.name = "expression is part of expression"
+        prop.name_reverse = "expression has part expression"
         prop.save()
 
 
@@ -901,10 +905,17 @@ def construct_properties():
         objects=[Expression],
     )
 
-    is_part_of_expression = create_properties(
-        name="is part of",
-        name_reverse="has part",
-        subjects=[Expression, Work],
+    expression_is_part_of_expression = create_properties(
+        name="expression is part of expression",
+        name_reverse="expression has part expression",
+        subjects=[Expression],
+        objects=[Expression],
+    )
+
+    work_is_part_of_expression = create_properties(
+        name="work is part of expression",
+        name_reverse="expression has part work",
+        subjects=[Work],
         objects=[Expression],
     )
 


### PR DESCRIPTION
The new 'is part of' Work x Expression relation is meant to be distinct from the existing Expression x Expression relation. This commit differentiates between the two.

It also updates the wordings of the 'name_reverse' fields so content managers can tell the reverse relations apart in the UI.