### PR TITLE
Set ISO date by parsing/converting free-form Expression publication date

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -97,8 +97,9 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 
-# Internationalization
+# Internationalization / Globalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
+# https://docs.djangoproject.com/en/4.2/ref/settings/#globalization-i18n-l10n
 
 LANGUAGE_CODE = "de"
 
@@ -108,6 +109,31 @@ USE_I18N = True
 
 USE_TZ = True
 
+# Date formats allowed in date fields in Django forms
+# https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+DATE_INPUT_FORMATS = [
+    # %m, %d are zero-padded
+    "%Y-%m-%d",  # 1996-02-29
+    "%Y-%m",  # 2015-10
+    "%Y",  # 1999
+    "%m/%Y",  # 2/2002
+    "%m.%Y",  # 2.2002
+    # formats only needed for forms, not for dateparser with DMY language set
+    "%d.%m.%Y",  # 9.7.1982, 18.4.1963
+    "%d/%m/%Y",  # 9/7/1982, 18/4/1963
+    "%d-%m-%Y",  # 23-12-1980
+]
+
+# dateparser settings used for handling incomplete/ambiguous dates
+# https://dateparser.readthedocs.io/en/latest/settings.html
+DATEPARSER_SETTINGS = {
+    "PREFER_DAY_OF_MONTH": "first",
+    "PREFER_MONTH_OF_YEAR": "first",
+    "PREFER_DATES_FROM": "future",
+    "TIMEZONE": TIME_ZONE,
+    "REQUIRE_PARTS": ["year"],
+    "STRICT_PARSING": True,
+}
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/

--- a/poetry.lock
+++ b/poetry.lock
@@ -352,6 +352,28 @@ jsbeautifier = "*"
 six = ">=1.13.0"
 
 [[package]]
+name = "dateparser"
+version = "1.2.0"
+description = "Date parsing library designed to parse dates from HTML pages"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "dateparser-1.2.0-py2.py3-none-any.whl", hash = "sha256:0b21ad96534e562920a0083e97fd45fa959882d4162acc358705144520a35830"},
+    {file = "dateparser-1.2.0.tar.gz", hash = "sha256:7975b43a4222283e0ae15be7b4999d08c9a70e2d378ac87385b1ccf2cffbbb30"},
+]
+
+[package.dependencies]
+python-dateutil = "*"
+pytz = "*"
+regex = "<2019.02.19 || >2019.02.19,<2021.8.27 || >2021.8.27"
+tzlocal = "*"
+
+[package.extras]
+calendars = ["convertdate", "hijri-converter"]
+fasttext = ["fasttext"]
+langdetect = ["langdetect"]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 description = "XML bomb protection for Python stdlib modules"
@@ -1803,6 +1825,23 @@ files = [
 ]
 
 [[package]]
+name = "tzlocal"
+version = "5.2"
+description = "tzinfo object for the local timezone"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tzlocal-5.2-py3-none-any.whl", hash = "sha256:49816ef2fe65ea8ac19d19aa7a1ae0551c834303d5014c6d5a62e4cbda8047b8"},
+    {file = "tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
+
+[[package]]
 name = "unicodecsv"
 version = "0.14.1"
 description = "Python2's stdlib csv module is nice, but it doesn't support unicode. This module is a drop-in replacement which *does*."
@@ -1857,4 +1896,4 @@ brotli = ["Brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b943e51d9723d5184ca4f3959eab15c93da1016642d782915360009dbf8c3230"
+content-hash = "8bbaf61502afb870ae242db11954862590eb523f558228e04c108e6ff25f2e24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{include = "apis_ontology"}]
 python = "^3.11"
 apis-acdhch-default-settings = "v0.1.24"
 apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.12.6"}
+dateparser = "^1.2.0"
 Django = "^4.2.7"
 django-extensions = "^3.2.3"
 django-multiselectfield = "^0.1.12"


### PR DESCRIPTION
Use `dateparser` library to update non-editable date field `publication_date_iso` whenever free-form `publication_date` field is changed:

* override `__init__` method  for `Expression` entity to preserve current `publication_date` in variable
* override `save` method – including when `update_fields=...` option is set to relevant fields – to parse/set the ISO date

Allowed date formats are set via Django's `DATE_INPUT_FORMATS` variable.