### PR TITLE
Fix rendering of custom table columns for full title, full name

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -7,6 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from multiselectfield import MultiSelectField
+import re
 
 
 @reversion.register
@@ -142,6 +143,19 @@ class TitlesMixin(models.Model):
 
     class Meta:
         abstract = True
+
+    def full_title(self):
+        full_title = self.title
+        subtitle = self.subtitle
+        letter_or_digit = re.compile(r"[\W\d]", re.U)
+
+        if subtitle:
+            if letter_or_digit.match(subtitle[0]):
+                full_title += f" {subtitle}"
+            else:
+                full_title += f". {subtitle}"
+
+        return full_title
 
 
 @reversion.register

--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -120,6 +120,26 @@ class PersonNameMixin(AlternativeNameMixin, models.Model):
     class Meta:
         abstract = True
 
+    def full_name(self):
+        full_name = ""
+        surname = self.surname
+        forename = self.forename
+        fallback_name = self.fallback_name
+
+        if fallback_name != "":
+            full_name = fallback_name
+        else:
+            if forename != "" and surname != "":
+                full_name = f"{forename} {surname}"
+            elif surname != "":
+                full_name = surname
+            elif forename != "":
+                full_name = forename
+            else:
+                pass
+
+        return full_name
+
 
 @reversion.register
 class TitlesMixin(models.Model):

--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -49,35 +49,14 @@ class FullTitleMixin(tables.Table):
 
 class FullNameMixin(tables.Table):
     full_name = GenericEditLinkColumn(
-        accessor="surname",
+        accessor="full_name",
         verbose_name=_("Name (voller)"),
-        order_by=("surname", "forename"),
+        order_by=("fallback_name", "surname", "forename"),
     )
 
     class Meta:
-        sequence = ("full_name", "surname", "forename")
-        exclude = ["surname", "forename"]
-
-    def render_full_name(self, record):
-        surname = record.surname
-        forename = record.forename
-        fallback_name = record.fallback_name
-
-        if fallback_name != "":
-            full_name = fallback_name
-        else:
-            if forename != "" and surname != "":
-                full_name = f"{forename} {surname}"
-            elif surname != "":
-                full_name = surname
-            elif forename != "":
-                full_name = forename
-            else:
-                # TODO log as error instead of exiting program
-                f"Missing name to look up or create Person, exiting."
-                exit(1)
-
-        return full_name
+        sequence = ("full_name", "fallback_name", "surname", "forename")
+        exclude = ["fallback_name", "surname", "forename"]
 
 
 class BaseEntityTable(AbstractEntityTable, tables.Table):

--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -37,7 +37,7 @@ class GenericEditLinkColumn(tables.Column):
 
 class FullTitleMixin(tables.Table):
     full_title = GenericEditLinkColumn(
-        accessor="title",
+        accessor="full_title",
         verbose_name=_("Titel (gesamt)"),
         order_by=("title", "subtitle"),
     )
@@ -45,15 +45,6 @@ class FullTitleMixin(tables.Table):
     class Meta:
         sequence = ("full_title", "title", "subtitle")
         exclude = ["title", "subtitle"]
-
-    def render_full_title(self, record):
-        full_title = record.title
-        subtitle = record.subtitle
-
-        if subtitle:
-            full_title += f". {subtitle}"
-
-        return full_title
 
 
 class FullNameMixin(tables.Table):


### PR DESCRIPTION
Switch to using model methods over `render_FOO` methods in tables for more flexibility in how/where custom strings can be used.