### PR TITLE
feat(models): override deprecated_name verbose_name

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -916,6 +916,10 @@ class Interpretatem(GenericNameMixin, DescriptionMixin, StatusMixin, AbstractEnt
         verbose_name_plural = _("interpretateme")
 
 
+deprecated_name = AbstractEntity._meta.get_field("deprecated_name")
+deprecated_name.verbose_name = "[deprecated; ignore]"
+
+
 def create_properties(
     name_forward: str, name_reverse: str, subjects: list, objects: list
 ):


### PR DESCRIPTION
Implement temporary global workaround for how
`deprecated_name` is rendered in the UI so it
can be differentiated from new `name` field
inherited from `GenericNameMixin`.