### PR TITLE
fix(models): remove refs to deprecated_name

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -992,9 +992,6 @@ def create_properties(
     prop, created = Property.objects.get_or_create(
         name_forward=name_forward,
         name_reverse=name_reverse,
-        # TODO remove once handling of "deprecated_name" vs. "name_forward"
-        #  is fixed in APIS CORE
-        deprecated_name=name_forward,
     )
 
     prop.subj_class.clear()
@@ -1044,9 +1041,6 @@ def update_properties():
     ):
         prop.name_forward = "expression is part of expression"
         prop.name_reverse = "expression has part expression"
-        # TODO remove once handling of "deprecated_name" vs. "name_forward"
-        #  is fixed in APIS CORE
-        prop.deprecated_name = "expression is part of expression"
         prop.save()
 
     # fix name_reverse of Binnenverweis relation


### PR DESCRIPTION
Remove leftover references to now-removed field
deprecated_name from relations-related functions.

Closes: #101