### PR TITLE
build: add file-specific Ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ format_js=false
 
 [tool.ruff]
 lint.ignore = ["E501", "F403"]
+
+[tool.ruff.lint.per-file-ignores]
+"**/settings.py" = ["F405"]


### PR DESCRIPTION
Ignore Ruff linting error F405 for settings.py to
allow inheritance of all variables defined in
apis-acdhch-default-settings dependency.