### PR TITLE
feat(api): return (enum) choices labels

### DIFF
--- a/apis_ontology/api/serializers.py
+++ b/apis_ontology/api/serializers.py
@@ -9,6 +9,22 @@ from rest_framework import serializers
 from apis_ontology.models import Expression, Work, WorkType
 
 
+def get_choices_labels(values: list, text_choices):
+    """
+    Return labels for enumeration type TextChoices.
+
+    :param values: an array of (valid) TextChoices values
+    :param text_choices: the TextChoices class against which to match the values
+    :return: a list of labels
+    """
+    labels = []
+
+    for v in values:
+        labels.append(text_choices(v).label)
+
+    return labels
+
+
 class WorkTypeDataSerializer(serializers.ModelSerializer):
     class Meta:
         model = WorkType
@@ -24,6 +40,8 @@ class ExpressionDataSerializer(serializers.ModelSerializer):
     place_of_publication = serializers.ListField(
         child=serializers.CharField(allow_blank=True), required=False, allow_empty=True
     )
+    edition_type = serializers.SerializerMethodField()
+    language = serializers.SerializerMethodField()
 
     class Meta:
         model = Expression
@@ -37,6 +55,16 @@ class ExpressionDataSerializer(serializers.ModelSerializer):
             "publisher",
             "place_of_publication",
         ]
+
+    def get_edition_type(self, obj):
+        edition_type_str = obj.get("edition_type", None)
+        edition_types = list(filter(None, edition_type_str.split(",")))
+        return get_choices_labels(edition_types, Expression.EditionTypes)
+
+    def get_language(self, obj):
+        language_str = obj.get("language", None)
+        languages = list(filter(None, language_str.split(",")))
+        return get_choices_labels(languages, Expression.Languages_ISO_639_3)
 
 
 class WorkPreviewSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
For multiple-choice fields implemented with
django-multiselectfield and TextChoices, return
the choices' (German language) labels rather than
their values.