### PR TITLE
implement first filter for work-preview endpoint

### DIFF
--- a/apis_ontology/api/filters.py
+++ b/apis_ontology/api/filters.py
@@ -1,0 +1,26 @@
+"""
+Filters for custom API.
+
+I.e. project-specific endpoints (not APIS built-in API).
+"""
+
+import logging
+
+import django_filters
+from django.utils.translation import gettext_lazy as _
+
+from apis_ontology.filtersets import fuzzy_search_unaccent_trigram
+
+
+logger = logging.getLogger(__name__)
+
+
+class WorkPreviewSearchFilter(django_filters.FilterSet):
+    search = django_filters.CharFilter(
+        field_name=[
+            "title",
+            "subtitle",
+        ],
+        label=_("Suche"),
+        method=fuzzy_search_unaccent_trigram,
+    )

--- a/apis_ontology/api/views.py
+++ b/apis_ontology/api/views.py
@@ -7,15 +7,14 @@ I.e. project-specific endpoints (not APIS built-in API).
 from django.contrib.postgres.expressions import ArraySubquery, Subquery
 from django.db.models import OuterRef
 from django.db.models.functions import JSONObject
-from rest_framework import permissions, viewsets
-from rest_framework.pagination import LimitOffsetPagination, Response
+from rest_framework import pagination, permissions, viewsets
 
 from apis_ontology.models import Expression, Organisation, Place, Work, WorkType
 
 from .serializers import WorkPreviewSerializer
 
 
-class WorkPreviewPagination(LimitOffsetPagination):
+class WorkPreviewPagination(pagination.LimitOffsetPagination):
     default_limit = 20
     max_limit = 100
 
@@ -27,7 +26,7 @@ class WorkPreviewPagination(LimitOffsetPagination):
                 self.offset_query_param: self.offset,
             }
         )
-        return Response(dict(sorted(response.data.items())))
+        return pagination.Response(dict(sorted(response.data.items())))
 
     def get_paginated_response_schema(self, schema):
         res_schema = super(WorkPreviewPagination, self).get_paginated_response_schema(
@@ -71,51 +70,49 @@ class WorkPreviewViewSet(viewsets.ReadOnlyModelViewSet):
         work_types = WorkType.objects.filter(
             triple_set_from_obj__subj_id=OuterRef("pk"),
             triple_set_from_obj__prop__name_forward__in=["has type"],
+        ).values(
+            json=JSONObject(
+                name="name",
+                name_plural="name_plural",
+            )
         )
 
         expression_publisher = Organisation.objects.filter(
             triple_set_from_subj__obj_id=OuterRef("pk"),
             triple_set_from_subj__prop__name_reverse__in=["has publisher"],
-        )
+        ).values("name")
 
         expression_place = Place.objects.filter(
             triple_set_from_obj__subj_id=OuterRef("pk"),
             triple_set_from_obj__prop__name_forward__in=["is published in"],
-        )
+        ).values_list("name")
 
-        related_expressions = Expression.objects.filter(
-            triple_set_from_obj__subj_id=OuterRef("pk"),
-            triple_set_from_obj__prop__name_reverse__in=["realises"],
-        ).annotate(
-            publisher=Subquery(expression_publisher.values("name")),
-            place=ArraySubquery(expression_place.values_list("name")),
+        related_expressions = (
+            Expression.objects.filter(
+                triple_set_from_obj__subj_id=OuterRef("pk"),
+                triple_set_from_obj__prop__name_reverse__in=["realises"],
+            ).annotate(
+                publisher=Subquery(expression_publisher),
+                place=ArraySubquery(expression_place),
+            )
+        ).values(
+            json=JSONObject(
+                title="title",
+                subtitle="subtitle",
+                edition="edition",
+                edition_type="edition_type",
+                language="language",
+                publication_date="publication_date_iso_formatted",
+                publisher="publisher",
+                place_of_publication="place",
+            )
         )
 
         works = (
             Work.objects.all()
             .annotate(
-                expression_data=ArraySubquery(
-                    related_expressions.values(
-                        json=JSONObject(
-                            title="title",
-                            subtitle="subtitle",
-                            edition="edition",
-                            edition_type="edition_type",
-                            language="language",
-                            publication_date="publication_date_iso_formatted",
-                            publisher="publisher",
-                            place_of_publication="place",
-                        )
-                    )
-                ),
-                work_type=ArraySubquery(
-                    work_types.values(
-                        json=JSONObject(
-                            name="name",
-                            name_plural="name_plural",
-                        )
-                    ),
-                ),
+                expression_data=ArraySubquery(related_expressions),
+                work_type=ArraySubquery(work_types),
             )
             .order_by("title", "subtitle")
         )

--- a/apis_ontology/api/views.py
+++ b/apis_ontology/api/views.py
@@ -7,10 +7,12 @@ I.e. project-specific endpoints (not APIS built-in API).
 from django.contrib.postgres.expressions import ArraySubquery, Subquery
 from django.db.models import OuterRef
 from django.db.models.functions import JSONObject
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import pagination, permissions, viewsets
 
 from apis_ontology.models import Expression, Organisation, Place, Work, WorkType
 
+from .filters import WorkPreviewSearchFilter
 from .serializers import WorkPreviewSerializer
 
 
@@ -65,6 +67,8 @@ class WorkPreviewViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = WorkPreviewSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
     pagination_class = WorkPreviewPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = WorkPreviewSearchFilter
 
     def get_queryset(self):
         work_types = WorkType.objects.filter(


### PR DESCRIPTION
Currently only works on `Work` `title` and `subtitle` -> `expression_data` needs to be filtered by string-based fields only before trigram-with-unaccent search can be run on it.