### PR TITLE
fix: add language facet to work preview endpoint

### DIFF
--- a/apis_ontology/api/filters.py
+++ b/apis_ontology/api/filters.py
@@ -26,3 +26,8 @@ class WorkPreviewSearchFilter(django_filters.FilterSet):
         ),
         method=fuzzy_search_unaccent_trigram,
     )
+    facet_language = django_filters.CharFilter(
+        field_name="triple_set_from_subj__obj__expression__language",
+        label=_("Language of the expression."),
+        lookup_expr="contains",
+    )


### PR DESCRIPTION
resolves gitlab issue 152

adds a first implementation of facets to the work preview endpoint.
Everything that is an annotation and is prefixed with "facet_" goes into facets. Needs array of strings or array of arrays to work.
Swagger definition is manually added to the endpoint.