### PR TITLE
fix(migrations): correct tuple

### DIFF
--- a/apis_ontology/migrations/0070_migrate_work_data_singlechoice_to_arrayfields.py
+++ b/apis_ontology/migrations/0070_migrate_work_data_singlechoice_to_arrayfields.py
@@ -7,7 +7,7 @@ RELEVANT_FIELDS = [
     ("temporal_order", "analysis_temporal_order"),
     ("temporal_duration", "analysis_temporal_duration"),
     ("temporal_frequency", "analysis_temporal_frequency"),
-    ("figure_speech", "analysis_figure_speech" "figure_speech"),
+    ("figure_speech", "analysis_figure_speech"),
     ("representation_of_thought", "analysis_representation_of_thought"),
     ("focalization", "analysis_focalization"),
     ("narrative_situation", "analysis_narrative_situation"),


### PR DESCRIPTION
Remove surplus element in tuple with field names in RELEVANT_FIELDS.
~~Non-functional change.~~ Oops, that surplus string is actually _not_ another element but would have got added to the preceding string... :grimacing:  Luckily, this was more of a trial data migration; affected data was considered test data (across a total of 2 objects).