### PR TITLE
build: add author to project/package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,10 @@
 name = "apis-instance-frischmuth"
 version = "0.2.0"
 description = "Digitales Archiv Barbara Frischmuth"
-authors = ["K Kollmann <dev-kk@oeaw.ac.at>"]
+authors = [
+    "K Kollmann <dev-kk@oeaw.ac.at>",
+    "Barbara Krautgartner <barbara.krautgartner@oeaw.ac.at>"
+]
 license = "MIT"
 repository = "https://github.com/acdh-oeaw/apis-instance-frischmuth"
 packages = [{include = "apis_ontology"}]


### PR DESCRIPTION
Supersedes #169.

Sole commit only adds another author, custom branch can hang around until whenever without getting in the way.