### PR TITLE
feat(api): set facet keys, counts required

### DIFF
--- a/apis_ontology/api/views.py
+++ b/apis_ontology/api/views.py
@@ -127,8 +127,14 @@ class WorkPreviewPagination(pagination.LimitOffsetPagination):
                         "items": {
                             "type": "object",
                             "properties": {
-                                "key": {"type": "string"},
-                                "count": {"type": "integer"},
+                                "key": {
+                                    "type": "string",
+                                    "required": True,
+                                },
+                                "count": {
+                                    "type": "integer",
+                                    "required": True,
+                                },
                             },
                         },
                         "example": [{"key": "eng", "count": 100}],
@@ -139,8 +145,14 @@ class WorkPreviewPagination(pagination.LimitOffsetPagination):
                         "items": {
                             "type": "object",
                             "properties": {
-                                "key": {"type": "string"},
-                                "count": {"type": "integer"},
+                                "key": {
+                                    "type": "string",
+                                    "required": True,
+                                },
+                                "count": {
+                                    "type": "integer",
+                                    "required": True,
+                                },
                             },
                         },
                         "example": [{"key": "Traum", "count": 3}],


### PR DESCRIPTION
In response schema for facets, set key, count
properties to "required" so they don't show up as
undefined in JSON schema.

Closes: #182