### PR TITLE
chore(deps): bump apis-acdhch-default-settings to v1.1.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -16,13 +16,13 @@ six = "*"
 
 [[package]]
 name = "apis-acdhch-default-settings"
-version = "1.1.0"
+version = "1.1.1"
 description = "Default settings for APIS instances at the ACDH-CH"
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "apis_acdhch_default_settings-1.1.0-py3-none-any.whl", hash = "sha256:460c8f5383ca83fa8e2ba7f817cb184a2600c338073d413df1960ddc165eebde"},
-    {file = "apis_acdhch_default_settings-1.1.0.tar.gz", hash = "sha256:5451378c14e8024d0863362a0fb054ada78a71df199239c0133881ff55641664"},
+    {file = "apis_acdhch_default_settings-1.1.1-py3-none-any.whl", hash = "sha256:edb73ba04811fb3798ff00698bdfcfa27babe4f4132122038d4ee3a28b4c9ecb"},
+    {file = "apis_acdhch_default_settings-1.1.1.tar.gz", hash = "sha256:a8bada3b41fbe1619cec8f343c7902481e6c5cecdbbccfc18510d091d6d22e98"},
 ]
 
 [package.dependencies]
@@ -1836,4 +1836,4 @@ brotli = ["Brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "0e541962bd7029609e39559d438b0954cd85e35600d46ff312cf36850c7edc6d"
+content-hash = "e9655932ac8c87d5d19bbd516296828636b037a76157753405b567eb0d7e6790"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [{include = "apis_ontology"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-apis-acdhch-default-settings = "v1.1.0"
+apis-acdhch-default-settings = "v1.1.1"
 apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.26.0"}
 dateparser = "^1.2.0"
 Django = "^4.2.7"


### PR DESCRIPTION
apis-core v0.26.0 changes how menu items are added to the relations
menu: the items are not hardcoded in the `base.html` template, but the
apps are responsible for overriding the `base.html` template and adding
them. therefore the order the apps are listed in INSTALLED_APPS is
important. apis-acdhch-default-settings v1.1.1 changes this order.
See commit 5f27f04146228d255a9e46dd53bb36e9947542a2 in the apis-core
repository.
