### PR TITLE
Sync handling of publishers, places between endpoints

### DIFF
--- a/apis_ontology/api/views.py
+++ b/apis_ontology/api/views.py
@@ -335,7 +335,7 @@ class WorkDetailViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
                 triple_set_from_obj__subj_id=OuterRef("pk"),
                 triple_set_from_obj__prop__name_reverse__in=["realises"],
             ).annotate(
-                publisher=Subquery(expression_publisher),
+                publisher=Subquery(expression_publisher[:1]),
                 places=ArraySubquery(expression_places),
             )
         ).values(

--- a/apis_ontology/api/views.py
+++ b/apis_ontology/api/views.py
@@ -214,10 +214,14 @@ class WorkPreviewViewSet(viewsets.ReadOnlyModelViewSet):
             triple_set_from_subj__prop__name_reverse__in=["has publisher"],
         ).values("name")
 
-        expression_places = Place.objects.filter(
-            triple_set_from_obj__subj_id=OuterRef("pk"),
-            triple_set_from_obj__prop__name_forward__in=["is published in"],
-        ).values_list("name")
+        expression_places = (
+            Place.objects.filter(
+                triple_set_from_obj__subj_id=OuterRef("pk"),
+                triple_set_from_obj__prop__name_forward__in=["is published in"],
+            )
+            .distinct()
+            .values_list("name")
+        )
 
         related_expressions = (
             Expression.objects.filter(


### PR DESCRIPTION
Harmonise:
* results returned for `expression_publisher`  `Subquery`
* `distinct`ness of `expression_places`

between the two endpoints.