### PR TITLE
refactor(api): return distinct publishers

### DIFF
--- a/apis_ontology/api/views.py
+++ b/apis_ontology/api/views.py
@@ -209,10 +209,14 @@ class WorkPreviewViewSet(viewsets.ReadOnlyModelViewSet):
             )
         )
 
-        expression_publisher = Organisation.objects.filter(
-            triple_set_from_subj__obj_id=OuterRef("pk"),
-            triple_set_from_subj__prop__name_reverse__in=["has publisher"],
-        ).values("name")
+        expression_publisher = (
+            Organisation.objects.filter(
+                triple_set_from_subj__obj_id=OuterRef("pk"),
+                triple_set_from_subj__prop__name_reverse__in=["has publisher"],
+            )
+            .distinct()
+            .values("name")
+        )
 
         expression_places = (
             Place.objects.filter(
@@ -228,7 +232,7 @@ class WorkPreviewViewSet(viewsets.ReadOnlyModelViewSet):
                 triple_set_from_obj__subj_id=OuterRef("pk"),
                 triple_set_from_obj__prop__name_reverse__in=["realises"],
             ).annotate(
-                publisher=Subquery(expression_publisher[:1]),
+                publisher=Subquery(expression_publisher),
                 places=ArraySubquery(expression_places),
             )
         ).values(
@@ -300,13 +304,17 @@ class WorkDetailViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
             )
         )
 
-        expression_publisher = Organisation.objects.filter(
-            triple_set_from_subj__obj_id=OuterRef("pk"),
-            triple_set_from_subj__prop__name_reverse__in=["has publisher"],
-        ).values(
-            json=JSONObject(
-                id="id",
-                name="name",
+        expression_publisher = (
+            Organisation.objects.filter(
+                triple_set_from_subj__obj_id=OuterRef("pk"),
+                triple_set_from_subj__prop__name_reverse__in=["has publisher"],
+            )
+            .distinct()
+            .values(
+                json=JSONObject(
+                    id="id",
+                    name="name",
+                )
             )
         )
 
@@ -339,7 +347,7 @@ class WorkDetailViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
                 triple_set_from_obj__subj_id=OuterRef("pk"),
                 triple_set_from_obj__prop__name_reverse__in=["realises"],
             ).annotate(
-                publisher=Subquery(expression_publisher[:1]),
+                publisher=Subquery(expression_publisher),
                 places=ArraySubquery(expression_places),
             )
         ).values(


### PR DESCRIPTION
Return distinct() expression_publishers to fix
errors resulting from duplicate relations set
between Expressions and Organisations + remove
current workaround of slicing returned publishers.