### PR TITLE
fix(static): improve multiselect widget

### DIFF
--- a/apis_ontology/static/css/core.css
+++ b/apis_ontology/static/css/core.css
@@ -1,0 +1,9 @@
+/* APIS Core main CSS */
+
+/* ACDH-CH logo in site footer */
+#logo {
+    height: 1.5em;
+}
+a #logo:hover {
+    opacity: 0.5;
+}

--- a/apis_ontology/static/css/core.css
+++ b/apis_ontology/static/css/core.css
@@ -7,3 +7,19 @@
 a #logo:hover {
     opacity: 0.5;
 }
+
+/* Frischmuth CSS add-ons */
+
+/* improve multiselect widget */
+/* remove redundant whitespace left of checkboxes,
+line up labels with right edge of checkboxes */
+.multiselect-native-select .multiselect-container > li > a > label {
+  padding: 3px 20px 3px 20px!important;
+  display: flex;
+}
+.multiselect-native-select .multiselect-container > li > a > label > input[type=checkbox] {
+  margin-top: .3em;
+  margin-right: .3em;
+  align-self: self-start;
+}
+


### PR DESCRIPTION
Add core.css to override CSS for dropdowns
with multi-select checkboxes.
Removes redundant whitespace in front of
(left of) select boxes, lines up labels
spanning multiple lines after (right of)
select boxes instead of letting them go
under them (first line indent style).