### PR TITLE
refactor(api): remove unused import

### DIFF
--- a/apis_ontology/api/serializers.py
+++ b/apis_ontology/api/serializers.py
@@ -4,7 +4,6 @@ Serializers for custom API.
 I.e. project-specific endpoints (not APIS built-in API).
 """
 
-from functools import cache
 from typing import TypedDict
 
 from django.contrib.postgres.expressions import Subquery


### PR DESCRIPTION
Fix Ruff linter workflow not passing due to
unused import statement.