### PR TITLE
fix: remove required fields from facets

### DIFF
--- a/apis_ontology/api/views.py
+++ b/apis_ontology/api/views.py
@@ -233,11 +233,9 @@ class WorkPreviewPagination(pagination.LimitOffsetPagination):
                             "properties": {
                                 "key": {
                                     "type": "string",
-                                    "required": True,
                                 },
                                 "count": {
                                     "type": "integer",
-                                    "required": True,
                                 },
                             },
                         },
@@ -256,11 +254,9 @@ class WorkPreviewPagination(pagination.LimitOffsetPagination):
                             "properties": {
                                 "key": {
                                     "type": "string",
-                                    "required": True,
                                 },
                                 "count": {
                                     "type": "integer",
-                                    "required": True,
                                 },
                             },
                         },
@@ -279,15 +275,12 @@ class WorkPreviewPagination(pagination.LimitOffsetPagination):
                             "properties": {
                                 "id": {
                                     "type": "integer",
-                                    "required": True,
                                 },
                                 "key": {
                                     "type": "string",
-                                    "required": True,
                                 },
                                 "count": {
                                     "type": "integer",
-                                    "required": True,
                                 },
                                 "children": {
                                     "type": "array",


### PR DESCRIPTION
resolves #263
The nested required fields in the facets swagger definition are not
allowed. Removed this for the moment to create a valid schema.