### PR TITLE
fix: override serialization of OpenAPI schema

### DIFF
--- a/apis_ontology/api/views.py
+++ b/apis_ontology/api/views.py
@@ -270,23 +270,7 @@ class WorkPreviewPagination(pagination.LimitOffsetPagination):
                     "work_type": {
                         "type": "array",
                         "nullable": True,
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "integer",
-                                },
-                                "key": {
-                                    "type": "string",
-                                },
-                                "count": {
-                                    "type": "integer",
-                                },
-                                "children": {
-                                    "$ref": "#/components/schemas/PaginatedWorkPreviewList/properties/facets/properties/work_type"
-                                },
-                            },
-                        },
+                        "items": {"$ref": "#/components/schemas/WorkTypeFacet"},
                         "example": [
                             {
                                 "id": 4,

--- a/apis_ontology/schema.py
+++ b/apis_ontology/schema.py
@@ -1,0 +1,16 @@
+def postprocess_facets(result, generator, request, public):
+    work_type_facet_component = {
+        "type": "object",
+        "required": ["id", "key", "count"],
+        "properties": {
+            "id": {"type": "integer"},
+            "key": {"type": "string"},
+            "count": {"type": "integer"},
+            "children": {
+                "type": "array",
+                "items": {"$ref": "#/components/schemas/WorkTypeFacet"},
+            },
+        },
+    }
+    result["components"]["schemas"]["WorkTypeFacet"] = work_type_facet_component
+    return result

--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -148,6 +148,10 @@ SPECTACULAR_SETTINGS["COMPONENT_NO_READ_ONLY_REQUIRED"] = True
 SPECTACULAR_SETTINGS["DEFAULT_GENERATOR_CLASS"] = (
     "apis_core.generic.generators.CustomSchemaGenerator"
 )
+SPECTACULAR_SETTINGS["POSTPROCESSING_HOOKS"] = [
+    "drf_spectacular.hooks.postprocess_schema_enums",
+    "apis_ontology.schema.postprocess_facets",
+]
 
 
 # Database


### PR DESCRIPTION
to fix the ref error of the JS generator we manually create
a component for work_type facet that we only reference in the
route.