### PR TITLE
fix: add `produced in` property [skip: ci]

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -1331,6 +1331,14 @@ def construct_properties():
         objects=[Place],
     )
 
+    # (film) produced in
+    create_properties(
+        name_forward="is produced in",
+        name_reverse="is place of production of",
+        subjects=[Expression],
+        objects=[Place],
+    )
+
     # CHARACTER-focussed relations
     # features
     create_properties(


### PR DESCRIPTION
property was added via admin interfaces, this is just for reproducibility of the db

resolves #326