### PR TITLE
fix: md parser expects `]` before `(`

### DIFF
--- a/apis_ontology/api/serializers.py
+++ b/apis_ontology/api/serializers.py
@@ -338,7 +338,7 @@ class WorkDetailSerializer(serializers.ModelSerializer):
     def get_context(self, obj) -> str:
         md = obj.context
         md = re.sub(
-            r"(?<=\()[0-9]+(?=\))",
+            r"(?<=\]\()[0-9]+(?=\))",
             lambda txt: RootObject.objects_inheritance.get_subclass(
                 pk=txt.group()
             ).get_frontend_url()


### PR DESCRIPTION
fixes an error where every year in brackets was treated as md link