### PR TITLE
fix: adapt search filter

### DIFF
--- a/apis_ontology/api/filters.py
+++ b/apis_ontology/api/filters.py
@@ -84,10 +84,12 @@ class WorkPreviewSearchFilter(django_filters.FilterSet):
         search_vector = SearchVector(
             "title", weight="A", config="german"
         ) + SearchVector(
-            "subtitle", weight="B", config="german"
+            "subtitle", "facet_topic", "authors", weight="B", config="german"
         )  # Combine fields for search
         search_query = SearchQuery(
-            value, config="german", search_type="websearch"
+            value.replace("*", ":*") if value.endswith("*") else value,
+            config="german",
+            search_type="raw" if value.endswith("*") else "websearch",
         )  # Search term
         results = (
             queryset.annotate(


### PR DESCRIPTION
adds authors and topics to general search; uses `raw` search in case the search term ends in "*" to allow for substring matching.

resolves #357